### PR TITLE
Enable colour output on composite monitors

### DIFF
--- a/src/pcplus.s
+++ b/src/pcplus.s
@@ -133,8 +133,8 @@ init_video_mode:
         ; save mode number
         push    ax
 
-        ; set video mode 5 (320x200 - 4 colors)
-        mov     ax,5
+        ; set video mode 4 (320x200 - 4 colors)
+        mov     ax,4
         int     10h
 
         ; enable ColorPlus extensions for 16 colors


### PR DESCRIPTION
Int 10 mode 5 sets the colour disable bit, which makes the game run in mono on the composite output. Using mode 4 works identically on RGB monitors, but enables colour on composite ones.